### PR TITLE
Add submodule DirectX-Headers to loose the requirement of Windows SDK version 10.0.22621.0 or later.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "thirdparty/Vulkan-Headers"]
 	path = thirdparty/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git
+[submodule "thirdparty/DirectX-Headers"]
+	path = thirdparty/DirectX-Headers
+	url = git@github.com:microsoft/DirectX-Headers.git
+	branch = tags/v1.615.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ if (NVRHI_WITH_VULKAN AND NOT TARGET Vulkan-Headers AND NOT TARGET Vulkan::Heade
     add_subdirectory(thirdparty/Vulkan-Headers)
 endif()
 
+if(NVRHI_WITH_DX12 AND NOT TARGET DirectX-Headers AND NOT TARGET Microsoft::DirectX-Headers)
+    add_subdirectory(thirdparty/DirectX-Headers)
+endif()
+
 if (NVRHI_WITH_RTXMU)
     if (TARGET Vulkan-Headers)
         get_target_property(RTXMU_VULKAN_INCLUDE_DIR Vulkan-Headers INTERFACE_INCLUDE_DIRECTORIES)
@@ -273,7 +277,7 @@ if (NVRHI_WITH_DX12)
         target_link_libraries(${nvrhi_d3d12_target} PUBLIC rtxmu)
     endif()
 
-    target_link_libraries(${nvrhi_d3d12_target} PUBLIC d3d12 dxguid)
+    target_link_libraries(${nvrhi_d3d12_target} PUBLIC Microsoft::DirectX-Headers Microsoft::DirectX-Guids d3d12)
 
     if (NVRHI_WITH_NVAPI)
         target_link_libraries(${nvrhi_d3d12_target} PUBLIC nvapi)

--- a/include/nvrhi/d3d12.h
+++ b/include/nvrhi/d3d12.h
@@ -28,7 +28,7 @@
 #define NOMINMAX
 #endif
 
-#include <d3d12.h>
+#include <directx/d3d12.h>
 
 namespace nvrhi
 {


### PR DESCRIPTION
As title says.