### PR TITLE
Fix typo: Rename Subrtact to Subtract

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -921,7 +921,7 @@ namespace nvrhi
     enum class BlendOp : uint8_t
     {
         Add = 1,
-        Subrtact = 2,
+        Subtract = 2,
         ReverseSubtract = 3,
         Min = 4,
         Max = 5

--- a/src/d3d11/d3d11-constants.cpp
+++ b/src/d3d11/d3d11-constants.cpp
@@ -80,7 +80,7 @@ namespace nvrhi::d3d11
         {
         case BlendOp::Add:
             return D3D11_BLEND_OP_ADD;
-        case BlendOp::Subrtact:
+        case BlendOp::Subtract:
             return D3D11_BLEND_OP_SUBTRACT;
         case BlendOp::ReverseSubtract:
             return D3D11_BLEND_OP_REV_SUBTRACT;

--- a/src/d3d12/d3d12-constants.cpp
+++ b/src/d3d12/d3d12-constants.cpp
@@ -104,7 +104,7 @@ namespace nvrhi::d3d12
         {
         case BlendOp::Add:
             return D3D12_BLEND_OP_ADD;
-        case BlendOp::Subrtact:
+        case BlendOp::Subtract:
             return D3D12_BLEND_OP_SUBTRACT;
         case BlendOp::ReverseSubtract:
             return D3D12_BLEND_OP_REV_SUBTRACT;

--- a/src/vulkan/vulkan-constants.cpp
+++ b/src/vulkan/vulkan-constants.cpp
@@ -690,7 +690,7 @@ namespace nvrhi::vulkan
             case BlendOp::Add:
                 return vk::BlendOp::eAdd;
 
-            case BlendOp::Subrtact:
+            case BlendOp::Subtract:
                 return vk::BlendOp::eSubtract;
 
             case BlendOp::ReverseSubtract:


### PR DESCRIPTION
### Fix typo: Rename `Subrtact` to `Subtract`

This pull request fixes a minor typo in the NVRHI codebase where `Subrtact` was misspelled. The corrected spelling is now `Subtract`.

#### Summary of Changes:
- Renamed all occurrences of `Subrtact` to `Subtract`.
- Updated relevant identifiers to maintain consistency.

This change improves code clarity and correctness without introducing any functional modifications.
