### PR TITLE
Use dimension parameter in CreateUAV

### DIFF
--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -643,7 +643,7 @@ namespace nvrhi::d3d12
 
         viewDesc.Format = getDxgiFormatMapping(format == Format::UNKNOWN ? desc.format : format).srvFormat;
 
-        switch (desc.dimension)
+        switch (dimension)
         {
         case TextureDimension::Texture1D:
             viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;


### PR DESCRIPTION
### Fix incorrect use of `desc.dimension` instead of `dimension` in `Texture::createUAV` in d3d12

This pull request corrects a likely oversight in the `Texture::createUAV` function, where the `desc.dimension` member was being used directly in a `switch` statement:

```cpp
switch (desc.dimension)
```
This has been replaced with:

```cpp
switch (dimension)
```
The function already contains logic to fallback to `desc.dimension` if the `dimension` parameter is `TextureDimension::Unknown`:
```cpp

void Texture::createUAV(size_t descriptor, Format format, TextureDimension dimension, TextureSubresourceSet subresources) const
{
    // ...
    if (dimension == TextureDimension::Unknown)
        dimension = desc.dimension;

    // ...
    
    switch (desc.dimension) // This is the old switch statement
    // ...
}
```

So using `desc.dimension` directly afterward bypassed the intended override mechanism. This fix ensures the correct and possibly overridden `dimension` parameter is used for selecting the appropriate view configuration.