### PR TITLE
Add #pragma once guard to common/resource.h

### DIFF
--- a/include/nvrhi/common/resource.h
+++ b/include/nvrhi/common/resource.h
@@ -20,6 +20,8 @@
 * DEALINGS IN THE SOFTWARE.
 */
 
+#pragma once 
+
 #include <atomic>
 #include <cstdint>
 #include <type_traits>


### PR DESCRIPTION
This change adds a #pragma once directive at the top of common/resource.h