### PR TITLE
Fix inconsistency between timer query behaviour on DX12 and Vulkan

### DIFF
--- a/src/vulkan/vulkan-queries.cpp
+++ b/src/vulkan/vulkan-queries.cpp
@@ -149,7 +149,10 @@ namespace nvrhi::vulkan
     {
         TimerQuery* query = checked_cast<TimerQuery*>(_query);
 
-        assert(query->started);
+        if (!query->started)
+        {
+            return false;
+        }
 
         if (query->resolved)
         {


### PR DESCRIPTION
On DX12, polling a timer query that had not been started would return false. However, doing the same on Vulkan would hit an assertion. This pull request modifies `nvrhi::vulkan::Device::pollTimerQuery` to return false if the query had not been started, which is the same behaviour as the DX12 implementation of timer queries.